### PR TITLE
Remove positive integer validation

### DIFF
--- a/src/Models/BorgRepository.php
+++ b/src/Models/BorgRepository.php
@@ -65,11 +65,6 @@ class BorgRepository extends ClusterModel implements Model
 
     public function setKeepHourly(int $keepHourly = null): BorgRepository
     {
-        Validator::value($keepHourly)
-            ->nullable()
-            ->positiveInteger()
-            ->validate();
-
         $this->keepHourly = $keepHourly;
 
         return $this;
@@ -82,11 +77,6 @@ class BorgRepository extends ClusterModel implements Model
 
     public function setKeepDaily(int $keepDaily = null): BorgRepository
     {
-        Validator::value($keepDaily)
-            ->nullable()
-            ->positiveInteger()
-            ->validate();
-
         $this->keepDaily = $keepDaily;
 
         return $this;
@@ -99,11 +89,6 @@ class BorgRepository extends ClusterModel implements Model
 
     public function setKeepWeekly(int $keepWeekly = null): BorgRepository
     {
-        Validator::value($keepWeekly)
-            ->nullable()
-            ->positiveInteger()
-            ->validate();
-
         $this->keepWeekly = $keepWeekly;
 
         return $this;
@@ -116,11 +101,6 @@ class BorgRepository extends ClusterModel implements Model
 
     public function setKeepMonthly(int $keepMonthly = null): BorgRepository
     {
-        Validator::value($keepMonthly)
-            ->nullable()
-            ->positiveInteger()
-            ->validate();
-
         $this->keepMonthly = $keepMonthly;
 
         return $this;
@@ -133,11 +113,6 @@ class BorgRepository extends ClusterModel implements Model
 
     public function setKeepYearly(int $keepYearly = null): BorgRepository
     {
-        Validator::value($keepYearly)
-            ->nullable()
-            ->positiveInteger()
-            ->validate();
-
         $this->keepYearly = $keepYearly;
 
         return $this;

--- a/src/Models/Cron.php
+++ b/src/Models/Cron.php
@@ -116,10 +116,6 @@ class Cron extends ClusterModel implements Model
 
     public function setErrorCount(int $errorCount): Cron
     {
-        Validator::value($errorCount)
-            ->positiveInteger()
-            ->validate();
-
         $this->errorCount = $errorCount;
 
         return $this;
@@ -132,10 +128,6 @@ class Cron extends ClusterModel implements Model
 
     public function setRandomDelayMaxSeconds(int $randomDelayMaxSeconds): Cron
     {
-        Validator::value($randomDelayMaxSeconds)
-            ->positiveInteger()
-            ->validate();
-
         $this->randomDelayMaxSeconds = $randomDelayMaxSeconds;
 
         return $this;

--- a/src/Models/FpmPool.php
+++ b/src/Models/FpmPool.php
@@ -71,10 +71,6 @@ class FpmPool extends ClusterModel implements Model
 
     public function setMaxChildren(int $maxChildren): FpmPool
     {
-        Validator::value($maxChildren)
-            ->positiveInteger()
-            ->validate();
-
         $this->maxChildren = $maxChildren;
 
         return $this;
@@ -87,10 +83,6 @@ class FpmPool extends ClusterModel implements Model
 
     public function setMaxRequests(int $maxRequests): FpmPool
     {
-        Validator::value($maxRequests)
-            ->positiveInteger()
-            ->validate();
-
         $this->maxRequests = $maxRequests;
 
         return $this;
@@ -103,10 +95,6 @@ class FpmPool extends ClusterModel implements Model
 
     public function setProcessIdleTimeout(int $processIdleTimeout): FpmPool
     {
-        Validator::value($processIdleTimeout)
-            ->positiveInteger()
-            ->validate();
-
         $this->processIdleTimeout = $processIdleTimeout;
 
         return $this;
@@ -119,11 +107,6 @@ class FpmPool extends ClusterModel implements Model
 
     public function setCpuLimit(?int $cpuLimit): FpmPool
     {
-        Validator::value($cpuLimit)
-            ->nullable()
-            ->positiveInteger()
-            ->validate();
-
         $this->cpuLimit = $cpuLimit;
 
         return $this;
@@ -136,11 +119,6 @@ class FpmPool extends ClusterModel implements Model
 
     public function setLogShowRequestsThreshold(?int $logShowRequestsThreshold): FpmPool
     {
-        Validator::value($logShowRequestsThreshold)
-            ->nullable()
-            ->positiveInteger()
-            ->validate();
-
         $this->logShowRequestsThreshold = $logShowRequestsThreshold;
 
         return $this;

--- a/src/Models/MailAccount.php
+++ b/src/Models/MailAccount.php
@@ -53,11 +53,6 @@ class MailAccount extends ClusterModel implements Model
 
     public function setQuota(?int $quota): MailAccount
     {
-        Validator::value($quota)
-            ->nullable()
-            ->positiveInteger()
-            ->validate();
-
         $this->quota = $quota;
 
         return $this;

--- a/src/Models/PassengerApp.php
+++ b/src/Models/PassengerApp.php
@@ -94,10 +94,6 @@ class PassengerApp extends ClusterModel implements Model
 
     public function setMaxPoolSize(int $maxPoolSize): PassengerApp
     {
-        Validator::value($maxPoolSize)
-            ->positiveInteger()
-            ->validate();
-
         $this->maxPoolSize = $maxPoolSize;
 
         return $this;
@@ -110,10 +106,6 @@ class PassengerApp extends ClusterModel implements Model
 
     public function setMaxRequests(int $maxRequests): PassengerApp
     {
-        Validator::value($maxRequests)
-            ->positiveInteger()
-            ->validate();
-
         $this->maxRequests = $maxRequests;
 
         return $this;
@@ -126,10 +118,6 @@ class PassengerApp extends ClusterModel implements Model
 
     public function setPoolIdleTime(int $poolIdleTime): PassengerApp
     {
-        Validator::value($poolIdleTime)
-            ->positiveInteger()
-            ->validate();
-
         $this->poolIdleTime = $poolIdleTime;
 
         return $this;
@@ -142,10 +130,6 @@ class PassengerApp extends ClusterModel implements Model
 
     public function setPort(int $port): PassengerApp
     {
-        Validator::value($port)
-            ->positiveInteger()
-            ->validate();
-
         $this->port = $port;
 
         return $this;
@@ -227,11 +211,6 @@ class PassengerApp extends ClusterModel implements Model
 
     public function setCpuLimit(?int $cpuLimit): PassengerApp
     {
-        Validator::value($cpuLimit)
-            ->nullable()
-            ->positiveInteger()
-            ->validate();
-
         $this->cpuLimit = $cpuLimit;
 
         return $this;

--- a/src/Models/RedisInstance.php
+++ b/src/Models/RedisInstance.php
@@ -43,10 +43,6 @@ class RedisInstance extends ClusterModel implements Model
 
     public function setMaxDatabases(int $maxDatabases): RedisInstance
     {
-        Validator::value($maxDatabases)
-            ->positiveInteger()
-            ->validate();
-
         $this->maxDatabases = $maxDatabases;
 
         return $this;
@@ -59,10 +55,6 @@ class RedisInstance extends ClusterModel implements Model
 
     public function setPort(int $port): RedisInstance
     {
-        Validator::value($port)
-            ->positiveInteger()
-            ->validate();
-
         $this->port = $port;
 
         return $this;
@@ -75,10 +67,6 @@ class RedisInstance extends ClusterModel implements Model
 
     public function setMemoryLimit(int $memoryLimit): RedisInstance
     {
-        Validator::value($memoryLimit)
-            ->positiveInteger()
-            ->validate();
-
         $this->memoryLimit = $memoryLimit;
 
         return $this;

--- a/src/Support/Validator.php
+++ b/src/Support/Validator.php
@@ -8,7 +8,6 @@ use Cyberfusion\ClusterApi\Exceptions\ValidationException;
 class Validator
 {
     private const NULLABLE = 'nullable';
-    private const POSITIVE_INTEGER = 'positive_integer';
     private const MAX_LENGTH = 'length_max';
     private const MIN_LENGTH = 'length_min';
     private const PATTERN = 'pattern';
@@ -43,12 +42,6 @@ class Validator
     public function nullable(): self
     {
         $this->validations[self::NULLABLE] = true;
-        return $this;
-    }
-
-    public function positiveInteger(): self
-    {
-        $this->validations[self::POSITIVE_INTEGER] = true;
         return $this;
     }
 
@@ -120,8 +113,6 @@ class Validator
     private function performValidation(string $type, $setting): bool
     {
         switch ($type) {
-            case self::POSITIVE_INTEGER:
-                return is_integer($this->value) && $this->value >= 0;
             case self::MAX_LENGTH:
                 return
                     (is_string($this->value) && Str::length($this->value) <= $setting) ||

--- a/tests/Support/ValidatorTest.php
+++ b/tests/Support/ValidatorTest.php
@@ -20,31 +20,13 @@ class ValidatorTest extends TestCase
     {
         $result = Validator::value(null)
             ->nullable()
-            ->positiveInteger()
+            ->email()
             ->validate();
         $this->assertTrue($result);
 
         $this->expectException(ValidationException::class);
         Validator::value(null)
-            ->positiveInteger()
-            ->validate();
-    }
-
-    public function testPositiveInteger()
-    {
-        $result = Validator::value(1)
-            ->positiveInteger()
-            ->validate();
-        $this->assertTrue($result);
-
-        $result = Validator::value(0)
-            ->positiveInteger()
-            ->validate();
-        $this->assertTrue($result);
-
-        $this->expectException(ValidationException::class);
-        Validator::value(-1)
-            ->positiveInteger()
+            ->email()
             ->validate();
     }
 


### PR DESCRIPTION
# Changes

Branched off https://github.com/CyberfusionNL/cyberfusion-cluster-api-client/pull/3

All integers must be positive. Therefore, this validation should either be removed or duplicated for each integer. I decided to remove it. Otherwise, there's too much code duplication. If we require a negative integer and/or 0 in the future, we should add a validator for that.

# Checks

- [ ] The version constant is updated in `Client.php`
- [ ] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
