### PR TITLE
Allow default nodejs version to be null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.72.1]
+
+### Fixed
+
+- Unix user might not have a default nodejs version but validation was not allowing `null`.
+
 ## [1.72.0]
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.72';
+    private const VERSION = '1.72.1';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Models/UnixUser.php
+++ b/src/Models/UnixUser.php
@@ -97,6 +97,7 @@ class UnixUser extends ClusterModel implements Model
     public function setDefaultNodejsVersion(?string $defaultNodejsVersion): UnixUser
     {
         Validator::value($defaultNodejsVersion)
+            ->nullable()
             ->pattern('^[0-9]{1,2}\.[0-9]{1,2}$')
             ->validate();
 


### PR DESCRIPTION
# Changes

Unix user might not have a default nodejs version but validation was not allowing `null`.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
