### PR TITLE
Fix several fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.75.1]
+
+### Fixed
+
+- Add `unit_name` as required field to the FPM pool update endpoint to match spec.
+- Add `record_usage_files` to the unix user create endpoint to match spec.
+- Add `home_directory` and `ssh_directory` to the fields and required fields for the unix user update endpoint to 
+  match spec.
+- Remove `domain_root` from the virtual host create endpoint to match spec.
+
 ## [1.75.0]
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.74';
+    private const VERSION = '1.75.1';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/FpmPools.php
+++ b/src/Endpoints/FpmPools.php
@@ -129,6 +129,7 @@ class FpmPools extends Endpoint
             'max_children',
             'id',
             'cluster_id',
+            'unit_name',
         ]);
 
         $request = (new Request())

--- a/src/Endpoints/UnixUsers.php
+++ b/src/Endpoints/UnixUsers.php
@@ -130,6 +130,7 @@ class UnixUsers extends Endpoint
                 'username',
                 'password',
                 'shell_path',
+                'record_usage_files',
                 'default_php_version',
                 'default_nodejs_version',
                 'virtual_hosts_directory',
@@ -171,6 +172,8 @@ class UnixUsers extends Endpoint
             'id',
             'cluster_id',
             'unix_id',
+            'home_directory',
+            'ssh_directory',
         ]);
 
         $request = (new Request())
@@ -180,20 +183,22 @@ class UnixUsers extends Endpoint
                 'username',
                 'password',
                 'shell_path',
+                'record_usage_files',
                 'default_php_version',
                 'default_nodejs_version',
                 'virtual_hosts_directory',
                 'mail_domains_directory',
                 'borg_repositories_directory',
                 'description',
-                'record_usage_files',
+                'cluster_id',
+                'id',
+                'unix_id',
+                'home_directory',
+                'ssh_directory',
                 'async_support_enabled',
                 'rabbitmq_username',
                 'rabbitmq_virtual_host_name',
                 'rabbitmq_password',
-                'id',
-                'cluster_id',
-                'unix_id',
             ]));
 
         $response = $this

--- a/src/Endpoints/VirtualHosts.php
+++ b/src/Endpoints/VirtualHosts.php
@@ -98,10 +98,9 @@ class VirtualHosts extends Endpoint
                 'force_ssl',
                 'custom_config',
                 'balancer_backend_name',
-                'domain_root',
+                'server_software_name',
                 'allow_override_directives',
                 'allow_override_option_directives',
-                'server_software_name',
             ]));
 
         $response = $this
@@ -135,12 +134,12 @@ class VirtualHosts extends Endpoint
             'server_aliases',
             'unix_user_id',
             'document_root',
-            'domain_root',
             'public_root',
             'force_ssl',
             'balancer_backend_name',
-            'server_software_name',
             'id',
+            'server_software_name',
+            'domain_root',
             'cluster_id',
         ]);
 
@@ -158,11 +157,11 @@ class VirtualHosts extends Endpoint
                 'force_ssl',
                 'custom_config',
                 'balancer_backend_name',
-                'domain_root',
+                'id',
+                'server_software_name',
                 'allow_override_directives',
                 'allow_override_option_directives',
-                'server_software_name',
-                'id',
+                'domain_root',
                 'cluster_id',
             ]));
 


### PR DESCRIPTION
# Changes

### Fixed

- Add `unit_name` as required field to the FPM pool update endpoint to match spec.
- Add `record_usage_files` to the unix user create endpoint to match spec.
- Add `home_directory` and `ssh_directory` to the fields and required fields for the unix user update endpoint to 
  match spec.
- Remove `domain_root` from the virtual host create endpoint to match spec.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
