### PR TITLE
Fix several RedisInstance issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.78.1]
+
+### Added
+
+- Add missing endpoint for destroying a RedisInstance.
+
+### Fixed
+
+- No longer require `max_databases` and `memory_limit` when creating or updating a RedisInstance.
+- Make RedisInstance port nullable as it's only available after creation.
+- Add default values for `max_databases` and `memory_limit`.
+
 ## [1.78.0]
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.78.0';
+    private const VERSION = '1.78.1';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/RedisInstances.php
+++ b/src/Endpoints/RedisInstances.php
@@ -75,9 +75,7 @@ class RedisInstances extends Endpoint
         $this->validateRequired($redisInstance, 'create', [
             'name',
             'password',
-            'max_databases',
             'primary_node_id',
-            'memory_limit',
             'cluster_id',
         ]);
 
@@ -87,9 +85,9 @@ class RedisInstances extends Endpoint
             ->setBody($this->filterFields($redisInstance->toArray(), [
                 'name',
                 'password',
+                'memory_limit',
                 'max_databases',
                 'primary_node_id',
-                'memory_limit',
                 'cluster_id',
             ]));
 
@@ -122,13 +120,11 @@ class RedisInstances extends Endpoint
         $this->validateRequired($redisInstance, 'update', [
             'name',
             'password',
-            'max_databases',
             'primary_node_id',
-            'memory_limit',
-            'port',
-            'unit_name',
             'cluster_id',
             'id',
+            'port',
+            'unit_name',
         ]);
 
         $request = (new Request())
@@ -138,12 +134,12 @@ class RedisInstances extends Endpoint
                 'name',
                 'password',
                 'max_databases',
-                'primary_node_id',
                 'memory_limit',
-                'port',
-                'unit_name',
+                'primary_node_id',
                 'cluster_id',
                 'id',
+                'port',
+                'unit_name',
             ]));
 
         $response = $this
@@ -163,5 +159,31 @@ class RedisInstances extends Endpoint
         return $response->setData([
             'redisInstance' => $redisInstance,
         ]);
+    }
+
+    /**
+     * @throws RequestException
+     */
+    public function delete(int $id): Response
+    {
+        // Log the affected cluster by retrieving the model first
+        $result = $this->get($id);
+        if ($result->isSuccess()) {
+            $clusterId = $result
+                ->getData('redisInstance')
+                ->getClusterId();
+
+            $this
+                ->client
+                ->addAffectedCluster($clusterId);
+        }
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_DELETE)
+            ->setUrl(sprintf('redis-instances/%d', $id));
+
+        return $this
+            ->client
+            ->request($request);
     }
 }

--- a/src/Models/RedisInstance.php
+++ b/src/Models/RedisInstance.php
@@ -10,9 +10,9 @@ class RedisInstance extends ClusterModel implements Model
 {
     private string $name;
     private string $password;
-    private int $maxDatabases;
-    private int $port;
-    private int $memoryLimit;
+    private int $maxDatabases = 16;
+    private ?int $port = null;
+    private int $memoryLimit = 100;
     private int $primaryNodeId;
     private ?string $unitName;
     private ?int $id = null;


### PR DESCRIPTION
# Changes

### Added

- Add missing endpoint for destroying a RedisInstance.

### Fixed

- No longer require `max_databases` and `memory_limit` when creating or updating a RedisInstance.
- Make RedisInstance port nullable as it's only available after creation.
- Add default values for `max_databases` and `memory_limit`.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
