### PR TITLE
Fix nullable values in RedisInstance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.78.2]
+
+### Fixed
+
+- Change `unit_name` to be nullable.
+- Fix the getters/setters of `port` to accept null value.
+
 ## [1.78.1]
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.78.1';
+    private const VERSION = '1.78.2';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Models/RedisInstance.php
+++ b/src/Models/RedisInstance.php
@@ -14,7 +14,7 @@ class RedisInstance extends ClusterModel implements Model
     private ?int $port = null;
     private int $memoryLimit = 100;
     private int $primaryNodeId;
-    private ?string $unitName;
+    private ?string $unitName = null;
     private ?int $id = null;
     private ?int $clusterId = null;
     private ?string $createdAt = null;
@@ -67,12 +67,12 @@ class RedisInstance extends ClusterModel implements Model
         return $this;
     }
 
-    public function getPort(): int
+    public function getPort(): ?int
     {
         return $this->port;
     }
 
-    public function setPort(int $port): RedisInstance
+    public function setPort(?int $port): RedisInstance
     {
         $this->port = $port;
 


### PR DESCRIPTION
# Changes

### Fixed

- Change `unit_name` to be nullable.
- Fix the getters/setters of `port` to accept null value.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
