### PR TITLE
Fix property name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.79.1]
+
+### Fixed
+
+- Rename the property `provider_names` to `provider_name` in the `CertificateManager` model.
+
 ## [1.79.0]
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.79.0';
+    private const VERSION = '1.79.1';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Models/CertificateManager.php
+++ b/src/Models/CertificateManager.php
@@ -140,7 +140,7 @@ class CertificateManager extends ClusterModel implements Model
         return $this
             ->setMainCommonName(Arr::get($data, 'main_common_name', ''))
             ->setCommonNames(Arr::get($data, 'common_names', []))
-            ->setProviderName(Arr::get($data, 'provider_names'))
+            ->setProviderName(Arr::get($data, 'provider_name'))
             ->setRequestCallbackUrl(Arr::get($data, 'request_callback_url'))
             ->setCertificateId(Arr::get($data, 'certificate_id'))
             ->setId(Arr::get($data, 'id'))
@@ -154,7 +154,7 @@ class CertificateManager extends ClusterModel implements Model
         return [
             'main_common_name' => $this->getMainCommonName(),
             'common_names' => $this->getCommonNames(),
-            'provider_names' => $this->getProviderName(),
+            'provider_name' => $this->getProviderName(),
             'request_callback_url' => $this->getRequestCallbackUrl(),
             'certificate_id' => $this->getCertificateId(),
             'id' => $this->getId(),


### PR DESCRIPTION
# Changes

### Fixed

- Rename the property `provider_names` to `provider_name` in the `CertificateManager` model.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
