### PR TITLE
Improve ListFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.81.0]
+
+### Changed
+
+- Improve the usage of the list filter.
+
 ## [1.80.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to 
-[Semantic Versioning](https://semver.org/spec/v2.0.0.html). Please note this changelog affects this package and not the 
-cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
-detailed information.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).. Please note this changelog affects 
+this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
+for detailed information.
 
 ## [1.81.0]
 
 ### Changed
 
-- Improve the usage of the list filter.
+- Improve the usage of the list filter. 
+- There should be just one breaking change, the `SORT_*` constants of the `ListFilter` are moved to a separate Enum, 
+  see `Enums\Sort`.
 
 ## [1.80.0]
 

--- a/README.md
+++ b/README.md
@@ -109,14 +109,14 @@ the model.
 
 ```php
 use Cyberfusion\ClusterApi\Enums\Sort;
-use Cyberfusion\ClusterApi\Models\Cluster;
+use Cyberfusion\ClusterApi\Models\VirtualHost;
 use Cyberfusion\ClusterApi\Support\FilterEntry;
 use Cyberfusion\ClusterApi\Support\SortEntry;
 
-$listFilter = Cluster::listFilter()
-    ->filter(new FilterEntry('name', 'test'))
-    ->filter(new FilterEntry('groups', 'test2'))
-    ->sort(new SortEntry('name', Sort::DESC));
+$listFilter = VirtualHost::listFilter()
+    ->filter(new FilterEntry('server_software_name', 'Apache'))
+    ->filter(new FilterEntry('domain', 'cyberfusion.nl'))
+    ->sort(new SortEntry('domain', Sort::DESC));
 ```
 
 ##### Manually creating filters
@@ -125,9 +125,9 @@ You can initialize the `ListFilter` manually, but fields are not validated if th
 
 ```php
 $listFilter = (new ListFilter())
-    ->filter(new FilterEntry('name', 'test'))
-    ->filter(new FilterEntry('groups', 'test2'))
-    ->sort(new SortEntry('name', Sort::DESC));
+    ->filter(new FilterEntry('server_software_name', 'Apache'))
+    ->filter(new FilterEntry('domain', 'cyberfusion.nl'))
+    ->sort(new SortEntry('domain', Sort::DESC));
 ```
 
 Or provide the entries and sort directly:
@@ -135,11 +135,11 @@ Or provide the entries and sort directly:
 ```php
 $listFilter = (new ListFilter())
     ->setFilters([
-        new FilterEntry('name', 'test'),
-        new FilterEntry('groups', 'test2'),
+        new FilterEntry('server_software_name', 'Apache'),
+        new FilterEntry('domain', 'cyberfusion.nl'),
     ])
     ->setSort([
-        new SortEntry('name', Sort::DESC)
+        new SortEntry('domain', Sort::DESC)
     ]);
 );
 ```
@@ -151,9 +151,9 @@ available.
 
 ```php
 $listFilter = ListFilter::forModel(new Cluster())
-    ->addFilter('name', 'test')
-    ->addFilter('groups', 'test2')
-    ->addSort('name', Sort::DESC);
+    ->filter('server_software_name', 'Apache')
+    ->filter('domain', 'cyberfusion.nl')
+    ->sort('domain', Sort::DESC);
 ```
 
 Or provide the entries and sort directly:
@@ -161,11 +161,11 @@ Or provide the entries and sort directly:
 ```php
 $listFilter = (new ListFilter())
     ->setFilters([
-        ['field' => 'name', 'value' => 'test'],
-        ['field' => 'groups', 'value' => 'test2'],
+        ['field' => 'server_software_name', 'value' => 'Apache'],
+        ['field' => 'domain', 'value' => 'cyberfusion.nl'],
     ])
     ->setSort([
-        ['field' => 'name', 'value' => Sort::DESC],
+        ['field' => 'domain', 'value' => Sort::DESC],
     ]);
 );
 ```

--- a/README.md
+++ b/README.md
@@ -102,13 +102,34 @@ Some endpoints require a `ListFilter` and return a list of models according to t
 A `ListFilter` can be initialized for a model, so it automatically validates if the provided fields are available for the model.
 
 ```php
-$listFilter = ListFilter::forModel(new Cluster());
-$listFilter->addFilter('name', 'test');
-$listFilter->addFilter('groups', 'test2');
-$listFilter->addSort('name', ListFilter::SORT_DESC);
+$listFilter = Cluster::filter()
+    ->addFilter(new FilterEntry('name', 'test'))
+    ->addFilter(new FilterEntry('groups', 'test2'))
+    ->addSort(new SortEntry('name', ListFilter::SORT_DESC));
 ```
 
 You are able to initialize the `ListFilter` manually, but fields are not validated in that case.
+
+```php
+$listFilter = (new ListFilter())
+    ->addFilter(new FilterEntry('name', 'test'))
+    ->addFilter(new FilterEntry('groups', 'test2'))
+    ->addSort(new SortEntry('name', ListFilter::SORT_DESC));
+```
+
+Or provide the entries and sort directly:
+
+```php
+$listFilter = new ListFilter(
+    [
+        new FilterEntry('name', 'test'),
+        new FilterEntry('groups', 'test2'),
+    ],
+    [
+        new SortEntry('name', ListFilter::SORT_DESC)
+    ]
+);
+```
 
 #### Manually make requests
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ This client was built for and tested on the **1.156** version of the API.
 
 ## Support
 
-This client is officially supported by Cyberfusion. If you have any questions, open an issue on GitHub or send an email to support@cyberfusion.nl.
+This client is officially supported by Cyberfusion. If you have any questions, open an issue on GitHub or email 
+support@cyberfusion.nl.
 
-The client was created by Vdhicts, a company which develops and implements IT solutions for businesses and educational institutions.
+The client was created by Vdhicts, a company which develops and implements IT solutions for businesses and educational 
+institutions.
 
 ## Requirements
 
@@ -97,51 +99,92 @@ When models need to be provided, the required properties are checked before exec
 
 #### Filtering data
 
-Some endpoints require a `ListFilter` and return a list of models according to the filter. It's also possible to change the sort order.
+Some endpoints require a `ListFilter` and return a list of models according to the filter. It's also possible to change 
+the sort order.
 
-A `ListFilter` can be initialized for a model, so it automatically validates if the provided fields are available for the model.
+##### Model filters
+
+A `ListFilter` can be initialized for a model, so it automatically validates if the provided fields are available for 
+the model.
 
 ```php
-$listFilter = Cluster::filter()
-    ->addFilter(new FilterEntry('name', 'test'))
-    ->addFilter(new FilterEntry('groups', 'test2'))
-    ->addSort(new SortEntry('name', ListFilter::SORT_DESC));
+use Cyberfusion\ClusterApi\Enums\Sort;
+use Cyberfusion\ClusterApi\Models\Cluster;
+use Cyberfusion\ClusterApi\Support\FilterEntry;
+use Cyberfusion\ClusterApi\Support\SortEntry;
+
+$listFilter = Cluster::listFilter()
+    ->filter(new FilterEntry('name', 'test'))
+    ->filter(new FilterEntry('groups', 'test2'))
+    ->sort(new SortEntry('name', Sort::DESC));
 ```
 
-You are able to initialize the `ListFilter` manually, but fields are not validated in that case.
+##### Manually creating filters
+
+You can initialize the `ListFilter` manually, but fields are not validated if they are available for the model.
 
 ```php
 $listFilter = (new ListFilter())
-    ->addFilter(new FilterEntry('name', 'test'))
-    ->addFilter(new FilterEntry('groups', 'test2'))
-    ->addSort(new SortEntry('name', ListFilter::SORT_DESC));
+    ->filter(new FilterEntry('name', 'test'))
+    ->filter(new FilterEntry('groups', 'test2'))
+    ->sort(new SortEntry('name', Sort::DESC));
 ```
 
 Or provide the entries and sort directly:
 
 ```php
-$listFilter = new ListFilter(
-    [
+$listFilter = (new ListFilter())
+    ->setFilters([
         new FilterEntry('name', 'test'),
         new FilterEntry('groups', 'test2'),
-    ],
-    [
-        new SortEntry('name', ListFilter::SORT_DESC)
-    ]
+    ])
+    ->setSort([
+        new SortEntry('name', Sort::DESC)
+    ]);
+);
+```
+
+##### Alternative method
+
+This package used to offer this way to build the filter. Due to backwards compatibility, this functionality is still 
+available.
+
+```php
+$listFilter = ListFilter::forModel(new Cluster())
+    ->addFilter('name', 'test')
+    ->addFilter('groups', 'test2')
+    ->addSort('name', Sort::DESC);
+```
+
+Or provide the entries and sort directly:
+
+```php
+$listFilter = (new ListFilter())
+    ->setFilters([
+        ['field' => 'name', 'value' => 'test'],
+        ['field' => 'groups', 'value' => 'test2'],
+    ])
+    ->setSort([
+        ['field' => 'name', 'value' => Sort::DESC],
+    ]);
 );
 ```
 
 #### Manually make requests
 
-To use the API directly, use the `request()` method on the `Client`. This method needs a `Request` class. See the class itself for its options.
+To use the API directly, use the `request()` method on the `Client`. This method needs a `Request` class. See the class 
+itself for its options.
 
 ### Responses
 
-The endpoint methods throw exceptions when requests fail due to timeouts. When the API replies with HTTP protocol errors, the `Response` class is returned nonetheless. Check if the request succeeded with: `$response->isSuccess()`. API responses are automatically converted to models.
+The endpoint methods throw exceptions when requests fail due to timeouts. When the API replies with HTTP protocol 
+errors, the `Response` class is returned nonetheless. Check if the request succeeded with: `$response->isSuccess()`. 
+API responses are automatically converted to models.
 
 ### Authentication
 
-The API is authenticated with a username and password and returns an access token. This client takes care of authentication. To get credentials, contact Cyberfusion.
+The API is authenticated with a username and password and returns an access token. This client takes care of 
+authentication. To get credentials, contact Cyberfusion.
 
 ```php
 $configuration = Configuration::withCredentials('username', 'password');
@@ -149,7 +192,8 @@ $configuration = Configuration::withCredentials('username', 'password');
 
 When you authenticate with username and password, this client automatically retrieves the access token.
 
-The access token is valid for 30 minutes, so there's no need to store it. To store it anyway, access it with `$configuration->getAccessToken()`.
+The access token is valid for 30 minutes, so there's no need to store it. To store it anyway, access it with 
+`$configuration->getAccessToken()`.
 
 #### Manually authenticate
 
@@ -196,15 +240,18 @@ All exceptions have a code. These can be found in the `ClusterApiException` clas
 
 ### Deployment
 
-Change to most of the objects in the Cluster API require a deployment of the cluster. See the [API documentation](https://cluster-api.cyberfusion.nl/redoc#operation/create_cluster_deployment_api_v1_cluster_deployments_post) for more information.
+Change to most of the objects in the Cluster API require a deployment of the cluster. See the [API documentation](https://cluster-api.cyberfusion.nl/redoc#operation/create_cluster_deployment_api_v1_cluster_deployments_post) 
+for more information.
 
-This client keeps track of changed clusters. The `deploy` method on the client automatically deploys all changed clusters:
+This client keeps track of changed clusters. The `deploy` method on the client automatically deploys all changed 
+clusters:
 
 ```php
 $clusterDeployments = $client->deploy();
 ```
 
-The result is an array of `Deployment` objects (or an empty array who no clusters are changed) which allows you to check if the cluster is properly deployed:
+The result is an array of `Deployment` objects (or an empty array who no clusters are changed) which allows you to 
+check if the cluster is properly deployed:
 
 ```php
 foreach ($clusterDeployments as $clusterDeployment) {
@@ -219,7 +266,8 @@ See the `Deployment` class for more options.
 
 #### Automatic deployment
 
-This client is also able to deploy all changed clusters automatically. This is opt-in behavior, as you won't be able to access the result of the deployment.
+This client is also able to deploy all changed clusters automatically. This is opt-in behavior, as you won't be able 
+to access the result of the deployment.
 
 ```php
 $configuration = new Configuration();

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.80.0';
+    private const VERSION = '1.81.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Exceptions/ClusterApiException.php
+++ b/src/Exceptions/ClusterApiException.php
@@ -17,10 +17,11 @@ class ClusterApiException extends Exception
     protected const API_NOT_UP = 300;
 
     protected const MODEL_PROPERTY_NOT_AVAILABLE = 400;
-    protected const MODEL_ENGINE_SET_AFTER_PASSWORD = 401;
 
     protected const VALIDATION_FAILED = 500;
 
     protected const LISTFILTER_INVALID_SORT_METHOD = 600;
     protected const LISTFILTER_FIELD_NOT_AVAILABLE = 601;
+    protected const LISTFILTER_INVALID_MODEL = 602;
+    protected const LISTFILTER_UNABLE_TO_DETERMINE_FIELDS = 603;
 }

--- a/src/Exceptions/ClusterApiException.php
+++ b/src/Exceptions/ClusterApiException.php
@@ -24,4 +24,6 @@ class ClusterApiException extends Exception
     protected const LISTFILTER_FIELD_NOT_AVAILABLE = 601;
     protected const LISTFILTER_INVALID_MODEL = 602;
     protected const LISTFILTER_UNABLE_TO_DETERMINE_FIELDS = 603;
+    protected const LISTFILTER_INVALID_TYPE = 604;
+    protected const LISTFILTER_INVALID_ARRAY_STRUCTURE = 605;
 }

--- a/src/Exceptions/ListFilterException.php
+++ b/src/Exceptions/ListFilterException.php
@@ -24,8 +24,10 @@ class ListFilterException extends ClusterApiException
         );
     }
 
-    public static function invalidSortMethod(string $providedSortMethod, Throwable $previous = null): ListFilterException
-    {
+    public static function invalidSortMethod(
+        string $providedSortMethod,
+        Throwable $previous = null
+    ): ListFilterException {
         return new self(
             sprintf('The sort method `%s` is not available, use ASC or DESC', $providedSortMethod),
             self::LISTFILTER_INVALID_SORT_METHOD,
@@ -38,6 +40,30 @@ class ListFilterException extends ClusterApiException
         return new self(
             sprintf('The field `%s` is not available in the model', $field),
             self::LISTFILTER_FIELD_NOT_AVAILABLE,
+            $previous
+        );
+    }
+
+    public static function invalidTypeInArray(string $foundType, Throwable $previous = null): ListFilterException
+    {
+        return new self(
+            sprintf(
+                'The array contains entries of the unsupported type `%s`',
+                $foundType
+            ),
+            self::LISTFILTER_INVALID_TYPE,
+            $previous
+        );
+    }
+
+    public static function arrayEntryKeysInvalid(array $requiredKeys, Throwable $previous = null): ListFilterException
+    {
+        return new self(
+            sprintf(
+                'The array must contains entries with at least these keys: `%s`',
+                var_export($requiredKeys, true)
+            ),
+            self::LISTFILTER_INVALID_ARRAY_STRUCTURE,
             $previous
         );
     }

--- a/src/Exceptions/ListFilterException.php
+++ b/src/Exceptions/ListFilterException.php
@@ -6,6 +6,24 @@ use Throwable;
 
 class ListFilterException extends ClusterApiException
 {
+    public static function invalidModel(Throwable $previous = null): ListFilterException
+    {
+        return new self(
+            'The provided model can\'t be use for a filter, the model must implement the `Model` contract',
+            self::LISTFILTER_INVALID_MODEL,
+            $previous
+        );
+    }
+
+    public static function unableToDetermineFields(Throwable $previous = null): ListFilterException
+    {
+        return new self(
+            'Unable to get the available fields for the model',
+            self::LISTFILTER_UNABLE_TO_DETERMINE_FIELDS,
+            $previous
+        );
+    }
+
     public static function invalidSortMethod(string $providedSortMethod, Throwable $previous = null): ListFilterException
     {
         return new self(
@@ -18,7 +36,7 @@ class ListFilterException extends ClusterApiException
     public static function fieldNotAvailable(string $field, Throwable $previous = null): ListFilterException
     {
         return new self(
-            sprintf('The `%s` is not available in the model', $field),
+            sprintf('The field `%s` is not available in the model', $field),
             self::LISTFILTER_FIELD_NOT_AVAILABLE,
             $previous
         );

--- a/src/Models/ClusterModel.php
+++ b/src/Models/ClusterModel.php
@@ -14,7 +14,7 @@ abstract class ClusterModel implements JsonSerializable, Model
     /**
      * @throws ListFilterException
      */
-    public static function filter(): ListFilter
+    public static function listFilter(): ListFilter
     {
         return ListFilter::forModel(get_called_class());
     }

--- a/src/Models/ClusterModel.php
+++ b/src/Models/ClusterModel.php
@@ -2,6 +2,8 @@
 
 namespace Cyberfusion\ClusterApi\Models;
 
+use Cyberfusion\ClusterApi\Exceptions\ListFilterException;
+use Cyberfusion\ClusterApi\Support\ListFilter;
 use JsonSerializable;
 use Cyberfusion\ClusterApi\Contracts\Model;
 use Cyberfusion\ClusterApi\Exceptions\ModelException;
@@ -9,6 +11,14 @@ use Cyberfusion\ClusterApi\Support\Str;
 
 abstract class ClusterModel implements JsonSerializable, Model
 {
+    /**
+     * @throws ListFilterException
+     */
+    public static function filter(): ListFilter
+    {
+        return ListFilter::forModel(get_called_class());
+    }
+
     /**
      * Provide fallback to allow the user of properties but still using the getters and setters.
      *

--- a/src/Support/Arr.php
+++ b/src/Support/Arr.php
@@ -21,4 +21,15 @@ class Arr extends \Illuminate\Support\Arr
 
         return $array;
     }
+
+    public static function keysExists(array $keys, array $source): bool
+    {
+        foreach ($keys as $key) {
+            if (! array_key_exists($key, $source)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/Support/FilterEntry.php
+++ b/src/Support/FilterEntry.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Support;
+
+class FilterEntry
+{
+    private string $field;
+    /** @var mixed */
+    private $value;
+
+    /**
+     * @param string $field
+     * @param mixed $value
+     */
+    public function __construct(string $field, $value)
+    {
+        $this->field = $field;
+        $this->value = $value;
+    }
+
+    public function getField(): string
+    {
+        return $this->field;
+    }
+
+    public function setField(string $field): self
+    {
+        $this->field = $field;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function setValue($value): self
+    {
+        $this->value = $value;
+        return $this;
+    }
+
+    public function toString(): string
+    {
+        return sprintf('%s:%s', $this->field, $this->value);
+    }
+}

--- a/src/Support/LogFilter.php
+++ b/src/Support/LogFilter.php
@@ -2,7 +2,6 @@
 
 namespace Cyberfusion\ClusterApi\Support;
 
-use Carbon\Carbon;
 use DateTimeInterface;
 use Cyberfusion\ClusterApi\Contracts\Filter;
 use Cyberfusion\ClusterApi\Enums\Limit;

--- a/src/Support/SortEntry.php
+++ b/src/Support/SortEntry.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Support;
+
+use Cyberfusion\ClusterApi\Enums\Sort;
+use Cyberfusion\ClusterApi\Exceptions\ListFilterException;
+
+class SortEntry
+{
+    private string $field;
+    private string $sort;
+
+    public function __construct(string $field, string $sort = Sort::ASC)
+    {
+        $this->field = $field;
+        $this->sort = $sort;
+    }
+
+    public function getField(): string
+    {
+        return $this->field;
+    }
+
+    public function setField(string $field): self
+    {
+        $this->field = $field;
+        return $this;
+    }
+
+    public function getSort(): string
+    {
+        return $this->sort;
+    }
+
+    public function setSort(string $sort): self
+    {
+        if (!in_array($sort, Sort::AVAILABLE)) {
+            throw ListFilterException::invalidSortMethod($sort);
+        }
+
+        $this->sort = $sort;
+        return $this;
+    }
+
+    public function toString(): string
+    {
+        return sprintf('%s:%s', $this->field, $this->sort);
+    }
+}

--- a/tests/Support/ListFilterTest.php
+++ b/tests/Support/ListFilterTest.php
@@ -2,6 +2,8 @@
 
 namespace Cyberfusion\ClusterApi\Tests\Support;
 
+use Cyberfusion\ClusterApi\Support\FilterEntry;
+use Cyberfusion\ClusterApi\Support\SortEntry;
 use PHPUnit\Framework\TestCase;
 use Cyberfusion\ClusterApi\Support\ListFilter;
 
@@ -24,10 +26,10 @@ class ListFilterTest extends TestCase
         $skip = 10;
         $limit = 5;
         $filter = [
-            ['field' => 'testField', 'value' => 'testValue'],
+            new FilterEntry('testField', 'testValue'),
         ];
         $sort = [
-            'col:ASC',
+            new SortEntry('col', 'ASC'),
         ];
 
         $listFilter = (new ListFilter())
@@ -49,12 +51,12 @@ class ListFilterTest extends TestCase
         $skip = 10;
         $limit = 5;
         $filter = [
-            ['field' => 'testField', 'value' => 'foo'],
-            ['field' => 'testField', 'value' => 'bar'],
-            ['field' => 'testField2', 'value' => 'lol'],
+            new FilterEntry('testField', 'foo'),
+            new FilterEntry('testField', 'bar'),
+            new FilterEntry('testField2', 'lol'),
         ];
         $sort = [
-            'col:ASC',
+            new SortEntry('col', 'ASC'),
         ];
 
         $listFilter = (new ListFilter())
@@ -64,7 +66,7 @@ class ListFilterTest extends TestCase
             ->setSort($sort);
 
         $this->assertSame(
-            'skip=10&limit=5&filter=testField%3Afoo&filter=testField%3Abar&filter=testField2%3Alol&sort=0%3Acol%3AASC',
+            'skip=10&limit=5&filter=testField%3Afoo&filter=testField%3Abar&filter=testField2%3Alol&sort=col%3AASC',
             $listFilter->toQuery()
         );
     }

--- a/tests/Support/ListFilterTest.php
+++ b/tests/Support/ListFilterTest.php
@@ -21,7 +21,57 @@ class ListFilterTest extends TestCase
         $this->assertCount(0, $listFilter->getSort());
     }
 
-    public function testListFilter()
+    public function testListFilterWithArrays()
+    {
+        $skip = 10;
+        $limit = 5;
+        $filter = [
+            ['field' => 'testField', 'value' => 'testValue'],
+        ];
+        $sort = [
+            ['field' => 'col', 'value' => 'ASC'],
+        ];
+
+        $listFilter = (new ListFilter())
+            ->setSkip($skip)
+            ->setLimit($limit)
+            ->setFilter($filter)
+            ->setSort($sort);
+
+        $this->assertSame($skip, $listFilter->getSkip());
+        $this->assertSame($limit, $listFilter->getLimit());
+        $this->assertIsArray($listFilter->getFilter());
+        $this->assertCount(1, $listFilter->getFilter());
+        $this->assertIsArray($listFilter->getSort());
+        $this->assertCount(1, $listFilter->getSort());
+    }
+
+    public function testToQueryWithArrays()
+    {
+        $skip = 10;
+        $limit = 5;
+        $filter = [
+            ['field' => 'testField', 'value' => 'foo'],
+            ['field' => 'testField', 'value' => 'bar'],
+            ['field' => 'testField2', 'value' => 'lol'],
+        ];
+        $sort = [
+            ['field' => 'col', 'value' => 'ASC'],
+        ];
+
+        $listFilter = (new ListFilter())
+            ->setSkip($skip)
+            ->setLimit($limit)
+            ->setFilter($filter)
+            ->setSort($sort);
+
+        $this->assertSame(
+            'skip=10&limit=5&filter=testField%3Afoo&filter=testField%3Abar&filter=testField2%3Alol&sort=col%3AASC',
+            $listFilter->toQuery()
+        );
+    }
+
+    public function testListFilterWithObjects()
     {
         $skip = 10;
         $limit = 5;
@@ -46,7 +96,7 @@ class ListFilterTest extends TestCase
         $this->assertCount(1, $listFilter->getSort());
     }
 
-    public function testToQuery()
+    public function testToQueryWithObjects()
     {
         $skip = 10;
         $limit = 5;


### PR DESCRIPTION
Closes #17 

# Changes

Improve the usability of filtering the data:

```php
$listFilter = Cluster::listFilter()
    ->filter(new FilterEntry('name', 'test'))
    ->filter(new FilterEntry('groups', 'test2'))
    ->sort(new SortEntry('name', Sort::DESC));
```

But the original way still works:

```php
$listFilter = ListFilter::forModel(new Cluster())
    ->addFilter('name', 'test')
    ->addFilter('groups', 'test2')
    ->addSort('name', Sort::DESC);
```

Or combine those:

```php
$listFilter = Cluster::listFilter()
    ->addFilter('name', 'test')
    ->addFilter('groups', 'test2')
    ->addSort('name', Sort::DESC);
```

### Changed

- Improve the usage of the list filter. 
- Initialize the filter directly from the model.
- Show proper errors when using a non-compliant array structure when setting the filter or the sort entries.
- There should be just one **breaking change**, the `SORT_*` constants of the `ListFilter` are moved to a separate Enum, 
  see `Enums\Sort`.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
