### PR TITLE
Fix task collection/result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.80.1]
+
+### Fixed
+
+- Fix UUID casing for task collections `results` endpoint.
+- Make task result `message` nullable.
+
 ## [1.80.0]
 
 ### Changed

--- a/src/Endpoints/TaskCollections.php
+++ b/src/Endpoints/TaskCollections.php
@@ -18,7 +18,7 @@ class TaskCollections extends Endpoint
     {
         $request = (new Request())
             ->setMethod(Request::METHOD_GET)
-            ->setUrl(sprintf('task-collections/%d/results', $uuid));
+            ->setUrl(sprintf('task-collections/%s/results', $uuid));
 
         $response = $this
             ->client

--- a/src/Models/TaskResult.php
+++ b/src/Models/TaskResult.php
@@ -11,7 +11,7 @@ class TaskResult extends ClusterModel implements Model
 {
     private string $uuid;
     private string $description;
-    private string $message;
+    private ?string $message;
     private string $state;
 
     public function getUuid(): string
@@ -52,11 +52,12 @@ class TaskResult extends ClusterModel implements Model
         return $this->message;
     }
 
-    public function setMessage(string $message): TaskResult
+    public function setMessage(?string $message): TaskResult
     {
         Validator::value($message)
             ->maxLength(65535)
             ->pattern('^[ -~]+$')
+            ->nullable()
             ->validate();
 
         $this->message = $message;


### PR DESCRIPTION
# Changes

- Fix UUID casing for task collections `results` endpoint.
- Make task result `message` nullable.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
