### PR TITLE
Change raw_message to be nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ for detailed information.
 
 ### Fixed
 
-- Change `raw_message` to be nullable on the `AccessLog` and `ErrorLog` models, as those are turned of by default and 
+- Change `raw_message` to be nullable on the `AccessLog` and `ErrorLog` models, as those are turned off by default and 
   will return `null` in that case.
 
 ## [1.82.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.82.1]
+
+### Fixed
+
+- Change `raw_message` to be nullable on the `AccessLog` and `ErrorLog` models, as those are turned of by default and 
+  will return `null` in that case.
+
 ## [1.82.0]
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.82.0';
+    private const VERSION = '1.82.1';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Models/AccessLog.php
+++ b/src/Models/AccessLog.php
@@ -9,7 +9,7 @@ use Cyberfusion\ClusterApi\Support\Validator;
 class AccessLog extends ClusterModel implements Model
 {
     private string $remoteAddress;
-    private string $rawMessage;
+    private ?string $rawMessage;
     private string $method;
     private string $uri;
     private string $timestamp;
@@ -28,15 +28,16 @@ class AccessLog extends ClusterModel implements Model
         return $this;
     }
 
-    public function getRawMessage(): string
+    public function getRawMessage(): ?string
     {
         return $this->rawMessage;
     }
 
-    public function setRawMessage(string $rawMessage): self
+    public function setRawMessage(?string $rawMessage): self
     {
         Validator::value($rawMessage)
             ->maxLength(65535)
+            ->nullable()
             ->validate();
 
         $this->rawMessage = $rawMessage;

--- a/src/Models/ErrorLog.php
+++ b/src/Models/ErrorLog.php
@@ -9,7 +9,7 @@ use Cyberfusion\ClusterApi\Support\Validator;
 class ErrorLog extends ClusterModel implements Model
 {
     private string $remoteAddress;
-    private string $rawMessage;
+    private ?string $rawMessage;
     private string $method;
     private string $uri;
     private string $timestamp;
@@ -27,15 +27,16 @@ class ErrorLog extends ClusterModel implements Model
         return $this;
     }
 
-    public function getRawMessage(): string
+    public function getRawMessage(): ?string
     {
         return $this->rawMessage;
     }
 
-    public function setRawMessage(string $rawMessage): self
+    public function setRawMessage(?string $rawMessage): self
     {
         Validator::value($rawMessage)
             ->maxLength(65535)
+            ->nullable()
             ->validate();
 
         $this->rawMessage = $rawMessage;


### PR DESCRIPTION
### Fixed

- Change `raw_message` to be nullable on the `AccessLog` and `ErrorLog` models, as those are turned off by default and 
  will return `null` in that case.