### PR TITLE
Update to API version 1.158.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.83.0]
+
+### Added
+
+- Add `certificate_id` to Domain Routers.
+- Add `MailHostnames` endpoints.
+
 ## [1.82.1]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Client for the [Cyberfusion Cluster API](https://cluster-api.cyberfusion.nl/).
 
-This client was built for and tested on the **1.157** version of the API.
+This client was built for and tested on the **1.158** version of the API.
 
 ## Support
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.82.1';
+    private const VERSION = '1.83.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/DomainRouters.php
+++ b/src/Endpoints/DomainRouters.php
@@ -67,6 +67,7 @@ class DomainRouters extends Endpoint
                 'virtual_host_id',
                 'url_redirect_id',
                 'node_id',
+                'certificate_id',
                 'force_ssl',
                 'id',
                 'cluster_id',

--- a/src/Endpoints/MailHostnames.php
+++ b/src/Endpoints/MailHostnames.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Endpoints;
+
+use Cyberfusion\ClusterApi\Exceptions\RequestException;
+use Cyberfusion\ClusterApi\Models\MailHostname;
+use Cyberfusion\ClusterApi\Request;
+use Cyberfusion\ClusterApi\Response;
+use Cyberfusion\ClusterApi\Support\ListFilter;
+
+class MailHostnames extends Endpoint
+{
+    /**
+     * @param ListFilter|null $filter
+     * @return Response
+     * @throws RequestException
+     */
+    public function list(ListFilter $filter = null): Response
+    {
+        if (is_null($filter)) {
+            $filter = new ListFilter();
+        }
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('mail-hostnames?%s', $filter->toQuery()));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'mailHostnames' => array_map(
+                function (array $data) {
+                    return (new MailHostname())->fromArray($data);
+                },
+                $response->getData()
+            ),
+        ]);
+    }
+
+    /**
+     * @param int $id
+     * @return Response
+     * @throws RequestException
+     */
+    public function get(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('mail-hostnames/%d', $id));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'mailHostname' => (new MailHostname())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @param MailHostname $mailHostname
+     * @return Response
+     * @throws RequestException
+     */
+    public function create(MailHostname $mailHostname): Response
+    {
+        $this->validateRequired($mailHostname, 'create', [
+            'domain',
+            'cluster_id',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl('mail-hostnames')
+            ->setBody($this->filterFields($mailHostname->toArray(), [
+                'domain',
+                'certificate_id',
+                'cluster_id',
+            ]));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        $mailHostname = (new MailHostname())->fromArray($response->getData());
+
+        // Log which cluster is affected by this change
+        $this
+            ->client
+            ->addAffectedCluster($mailHostname->getClusterId());
+
+        return $response->setData([
+            'mailHostname' => $mailHostname,
+        ]);
+    }
+
+    /**
+     * @param MailHostname $mailHostname
+     * @return Response
+     * @throws RequestException
+     */
+    public function update(MailHostname $mailHostname): Response
+    {
+        $this->validateRequired($mailHostname, 'update', [
+            'domain',
+            'cluster_id',
+            'id',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_PUT)
+            ->setUrl(sprintf('mail-hostnames/%d', $mailHostname->getId()))
+            ->setBody($this->filterFields($mailHostname->toArray(), [
+                'domain',
+                'certificate_id',
+                'cluster_id',
+                'id',
+            ]));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        $mailHostname = (new MailHostname())->fromArray($response->getData());
+
+        // Log which cluster is affected by this change
+        $this
+            ->client
+            ->addAffectedCluster($mailHostname->getClusterId());
+
+        return $response->setData([
+            'mailHostname' => $mailHostname,
+        ]);
+    }
+
+    /**
+     * @param int $id
+     * @return Response
+     * @throws RequestException
+     */
+    public function delete(int $id): Response
+    {
+        // Log the affected cluster by retrieving the model first
+        $result = $this->get($id);
+        if ($result->isSuccess()) {
+            $clusterId = $result
+                ->getData('mailHostname')
+                ->getClusterId();
+
+            $this
+                ->client
+                ->addAffectedCluster($clusterId);
+        }
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_DELETE)
+            ->setUrl(sprintf('mail-hostnames/%d', $id));
+
+        return $this
+            ->client
+            ->request($request);
+    }
+}

--- a/src/Models/DomainRouter.php
+++ b/src/Models/DomainRouter.php
@@ -12,6 +12,7 @@ class DomainRouter extends ClusterModel implements Model
     private ?int $virtualHostId = null;
     private ?int $urlRedirectId = null;
     private ?int $nodeId = null;
+    private ?int $certificateId = null;
     private int $id;
     private int $clusterId;
     private ?string $createdAt = null;
@@ -77,6 +78,18 @@ class DomainRouter extends ClusterModel implements Model
         return $this;
     }
 
+    public function getCertificateId(): ?int
+    {
+        return $this->certificateId;
+    }
+
+    public function setCertificateId(?int $certificateId): self
+    {
+        $this->certificateId = $certificateId;
+
+        return $this;
+    }
+
     public function getId(): int
     {
         return $this->id;
@@ -133,6 +146,7 @@ class DomainRouter extends ClusterModel implements Model
             ->setVirtualHostId(Arr::get($data, 'virtual_host_id'))
             ->setUrlRedirectId(Arr::get($data, 'url_redirect_id'))
             ->setNodeId(Arr::get($data, 'node_id'))
+            ->setCertificateId(Arr::get($data, 'certificate_id'))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
@@ -147,6 +161,7 @@ class DomainRouter extends ClusterModel implements Model
             'virtual_host_id' => $this->getVirtualHostId(),
             'url_redirect_id' => $this->getUrlRedirectId(),
             'node_id' => $this->getNodeId(),
+            'certificate_id' => $this->getCertificateId(),
             'id' => $this->getId(),
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),

--- a/src/Models/MailHostname.php
+++ b/src/Models/MailHostname.php
@@ -46,10 +46,7 @@ class MailHostname extends ClusterModel implements Model
         $this->certificateId = $certificateId;
         return $this;
     }
-
-    /**
-     * @return int|null
-     */
+    
     public function getId(): ?int
     {
         return $this->id;

--- a/src/Models/MailHostname.php
+++ b/src/Models/MailHostname.php
@@ -19,7 +19,7 @@ class MailHostname extends ClusterModel implements Model
         return $this->domain;
     }
 
-    public function setDomain(string $domain): MailHostname
+    public function setDomain(string $domain): self
     {
         $this->domain = $domain;
         return $this;
@@ -30,7 +30,7 @@ class MailHostname extends ClusterModel implements Model
         return $this->clusterId;
     }
 
-    public function setClusterId(int $clusterId): MailHostname
+    public function setClusterId(int $clusterId): self
     {
         $this->clusterId = $clusterId;
         return $this;
@@ -41,18 +41,18 @@ class MailHostname extends ClusterModel implements Model
         return $this->certificateId;
     }
 
-    public function setCertificateId(?int $certificateId): MailHostname
+    public function setCertificateId(?int $certificateId): self
     {
         $this->certificateId = $certificateId;
         return $this;
     }
-    
+
     public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function setId(?int $id): MailHostname
+    public function setId(?int $id): self
     {
         $this->id = $id;
         return $this;
@@ -63,7 +63,7 @@ class MailHostname extends ClusterModel implements Model
         return $this->createdAt;
     }
 
-    public function setCreatedAt(?string $createdAt): MailHostname
+    public function setCreatedAt(?string $createdAt): self
     {
         $this->createdAt = $createdAt;
         return $this;
@@ -74,7 +74,7 @@ class MailHostname extends ClusterModel implements Model
         return $this->updatedAt;
     }
 
-    public function setUpdatedAt(?string $updatedAt): MailHostname
+    public function setUpdatedAt(?string $updatedAt): self
     {
         $this->updatedAt = $updatedAt;
         return $this;

--- a/src/Models/MailHostname.php
+++ b/src/Models/MailHostname.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Cyberfusion\ClusterApi\Models;
+
+use Cyberfusion\ClusterApi\Contracts\Model;
+use Cyberfusion\ClusterApi\Support\Arr;
+
+class MailHostname extends ClusterModel implements Model
+{
+    private string $domain;
+    private int $clusterId;
+    private ?int $certificateId = null;
+    private ?int $id = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getDomain(): string
+    {
+        return $this->domain;
+    }
+
+    public function setDomain(string $domain): MailHostname
+    {
+        $this->domain = $domain;
+        return $this;
+    }
+
+    public function getClusterId(): int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(int $clusterId): MailHostname
+    {
+        $this->clusterId = $clusterId;
+        return $this;
+    }
+
+    public function getCertificateId(): ?int
+    {
+        return $this->certificateId;
+    }
+
+    public function setCertificateId(?int $certificateId): MailHostname
+    {
+        $this->certificateId = $certificateId;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): MailHostname
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): MailHostname
+    {
+        $this->createdAt = $createdAt;
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): MailHostname
+    {
+        $this->updatedAt = $updatedAt;
+        return $this;
+    }
+
+    public function fromArray(array $data): self
+    {
+        return $this
+            ->setDomain(Arr::get($data, 'domain'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCertificateId(Arr::get($data, 'certificate_id'))
+            ->setId(Arr::get($data, 'id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'domain' => $this->getDomain(),
+            'cluster_id' => $this->getClusterId(),
+            'certificate_id' => $this->getCertificateId(),
+            'id' => $this->getId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
+        ];
+    }
+}


### PR DESCRIPTION
# Changes

### Added

- Add `certificate_id` to Domain Routers.
- Add `MailHostnames` endpoints.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
