### PR TITLE
Do not require `rabbitmq` for unix users as those are nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.86.1]
+
+### Fixed
+
+- Do not require `rabbitmq` for unix users as those are nullable.
+
 ## [1.86.0]
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.86.0';
+    private const VERSION = '1.86.1';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/UnixUsers.php
+++ b/src/Endpoints/UnixUsers.php
@@ -174,10 +174,6 @@ class UnixUsers extends Endpoint
             'unix_id',
             'home_directory',
             'ssh_directory',
-            'rabbitmq_username',
-            'rabbitmq_virtual_host_name',
-            'rabbitmq_password',
-            'rabbitmq_encryption_key',
         ]);
 
         $request = (new Request())


### PR DESCRIPTION
# Changes

### Fixed

- Do not require `rabbitmq` for unix users as those are nullable.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
