### PR TITLE
Fix filterFields for when no specific fields are passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.86.3]
+
+### Fixed
+
+- Fix `filterFields` when no specific fields are passed
+
 ## [1.86.2]
 
 ### Fixed

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.86.2';
+    private const VERSION = '1.86.3';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/Endpoint.php
+++ b/src/Endpoints/Endpoint.php
@@ -57,6 +57,10 @@ abstract class Endpoint
      */
     protected function filterFields(array $array, array $fields = []): array
     {
+        if (count($fields) === 0) {
+            return $array;
+        }
+
         return Arr::only($array, $fields);
     }
 }

--- a/src/Endpoints/Endpoint.php
+++ b/src/Endpoints/Endpoint.php
@@ -58,7 +58,7 @@ abstract class Endpoint
     protected function filterFields(array $array, array $fields = []): array
     {
         if (count($fields) === 0) {
-            return $array;
+            return array_filter($array);
         }
 
         return Arr::only($array, $fields);


### PR DESCRIPTION
# Changes

This PR is open for discussion. We're running into an issue with the `Authentication` -> `login` method. This method uses the `filterFields` method without specific fields defined. Passing the empty array to the `Arr::only` method will return no fields at all, which returns in authentication failure. This PR fixes this behaviour, but unsure if this is the best way to fix this.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
