### PR TITLE
Do not filter fields for the login endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.86.3]
+
+### Fixed
+
+- Do not filter fields for the login endpoints.
+
 ## [1.86.2]
 
 ### Fixed

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.86.2';
+    private const VERSION = '1.86.3';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/Authentication.php
+++ b/src/Endpoints/Authentication.php
@@ -21,7 +21,7 @@ class Authentication extends Endpoint
         $request = (new Request())
             ->setMethod(Request::METHOD_POST)
             ->setUrl('login/access-token')
-            ->setBody($this->filterFields($login->toArray()))
+            ->setBody($login->toArray())
             ->setAuthenticationRequired(false)
             ->setBodySchema(Request::BODY_SCHEMA_FORM);
 


### PR DESCRIPTION
# Changes

### Fixed

- Do not filter fields for the login endpoints.

Thanks to @mbardelmeijer 

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
