### PR TITLE
Properly apply nullable validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.86.4]
+
+### Fixed
+
+- Properly apply nullable validation in `BorgRepository`, `DatabaseUser` and `PassengerApp` models.
+
 ## [1.86.3]
 
 ### Fixed

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.86.3';
+    private const VERSION = '1.86.4';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Models/BorgRepository.php
+++ b/src/Models/BorgRepository.php
@@ -157,6 +157,7 @@ class BorgRepository extends ClusterModel implements Model
     public function setRemoteUsername(?string $remoteUsername): self
     {
         Validator::value($remoteUsername)
+            ->nullable()
             ->maxLength(32)
             ->pattern('^[a-z0-9-_]+$')
             ->validate();

--- a/src/Models/DatabaseUser.php
+++ b/src/Models/DatabaseUser.php
@@ -63,6 +63,7 @@ class DatabaseUser extends ClusterModel implements Model
     public function setPassword(?string $password): self
     {
         Validator::value($password)
+            ->nullable()
             ->maxLength(255)
             ->pattern('^[ -~]+$')
             ->validate();

--- a/src/Models/PassengerApp.php
+++ b/src/Models/PassengerApp.php
@@ -175,6 +175,7 @@ class PassengerApp extends ClusterModel implements Model
     public function setNodejsVersion(?string $nodejsVersion): self
     {
         Validator::value($nodejsVersion)
+            ->nullable()
             ->pattern('^[0-9]{1,2}\.[0-9]{1,2}$')
             ->validate();
 


### PR DESCRIPTION
Closes #37 

# Changes

### Fixed

- Properly apply nullable validation in `BorgRepository`, `DatabaseUser` and `PassengerApp` models.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
