### PR TITLE
Version 1.87

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.87.0]
+
+### Changed
+
+- The `files` attribute of the `UnixUserUsage` model is now nullable.
+
 ## [1.86.4]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Client for the [Cyberfusion Cluster API](https://cluster-api.cyberfusion.nl/).
 
-This client was built for and tested on the **1.164** version of the API.
+This client was built for and tested on the **1.166** version of the API.
 
 ## Support
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.86.4';
+    private const VERSION = '1.87.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Models/UnixUserUsage.php
+++ b/src/Models/UnixUserUsage.php
@@ -10,7 +10,7 @@ class UnixUserUsage extends ClusterModel implements Model
 {
     private int $unixUserId;
     private int $usage;
-    private array $files = [];
+    private ?array $files = null;
     private string $timestamp;
 
     public function getUnixUserId(): int
@@ -37,14 +37,15 @@ class UnixUserUsage extends ClusterModel implements Model
         return $this;
     }
 
-    public function getFiles(): array
+    public function getFiles(): ?array
     {
         return $this->files;
     }
 
-    public function setFiles(array $files): self
+    public function setFiles(?array $files): self
     {
         Validator::value($files)
+            ->nullable()
             ->each()
             ->path()
             ->validate();


### PR DESCRIPTION
# Changes

Update to API version 1.166.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
