### PR TITLE
Add Laravel 10 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.92.0]
+
+### Added
+
+- Add Laravel 10 support.
+
 ## [1.91.1]
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.2",
-        "illuminate/support": "^8.22 || ^9.0",
+        "illuminate/support": "^8.22 || ^9.0 || ^10.0",
         "nesbot/carbon": "^2.43",
         "ramsey/uuid": "^3.9 || ^4.0",
         "vdhicts/http-query-builder": "^1.0"

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.91.1';
+    private const VERSION = '1.92.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 


### PR DESCRIPTION
Closes #46 

# Changes

### Added

- Add Laravel 10 support.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
