### PR TITLE
Version 1.94.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.94.0]
+
+### Changed
+
+- Do not return task collection on virtual host delete. Virtual hosts are now deleted immediately.
+
 ## [1.93.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Client for the [Cyberfusion Cluster API](https://cluster-api.cyberfusion.nl/).
 
-This client was built for and tested on the **1.174** version of the API.
+This client was built for and tested on the **1.175** version of the API.
 
 ## Support
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.93.0';
+    private const VERSION = '1.94.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/Endpoints/VirtualHosts.php
+++ b/src/Endpoints/VirtualHosts.php
@@ -163,32 +163,15 @@ class VirtualHosts extends Endpoint
     /**
      * @throws RequestException
      */
-    public function delete(int $id, ?string $callbackUrl = null): Response
+    public function delete(int $id): Response
     {
-        $url = Str::optionalQueryParameters(
-            sprintf(
-                'virtual-hosts/%d',
-                $id,
-            ),
-            ['callback_url' => $callbackUrl]
-        );
-
         $request = (new Request())
             ->setMethod(Request::METHOD_DELETE)
-            ->setUrl($url);
+            ->setUrl(sprintf('virtual-hosts/%d', $id));
 
-        $response = $this
+        return $this
             ->client
             ->request($request);
-        if (!$response->isSuccess()) {
-            return $response;
-        }
-
-        $taskCollection = (new TaskCollection())->fromArray($response->getData());
-
-        return $response->setData([
-            'taskCollection' => $taskCollection,
-        ]);
     }
 
     /**


### PR DESCRIPTION
# Changes

Do not return task collection on virtual host delete. Virtual hosts are now deleted immediately.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
