### PR TITLE
Version 1.96.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.96.0]
+
+### Removed
+
+- Unit name from Redis instances, FPM pools, and Passenger apps.
+
 ## [1.95.0]
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Client for the [Cyberfusion Cluster API](https://cluster-api.cyberfusion.nl/).
 
-This client was built for and tested on the **1.177** version of the API.
+This client was built for and tested on the **1.179** version of the API.
 
 ## Support
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.95.0';
+    private const VERSION = '1.96.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/Endpoints/FpmPools.php
+++ b/src/Endpoints/FpmPools.php
@@ -116,7 +116,6 @@ class FpmPools extends Endpoint
             'max_children',
             'id',
             'cluster_id',
-            'unit_name',
         ]);
 
         $request = (new Request())

--- a/src/Endpoints/PassengerApps.php
+++ b/src/Endpoints/PassengerApps.php
@@ -122,7 +122,6 @@ class PassengerApps extends Endpoint
             'port',
             'app_type',
             'startup_file',
-            'unit_name',
         ]);
 
         $request = (new Request())
@@ -143,7 +142,6 @@ class PassengerApps extends Endpoint
                     'app_type',
                     'nodejs_version',
                     'startup_file',
-                    'unit_name',
                     'is_namespaced',
                     'cpu_limit',
                     'app_root',

--- a/src/Endpoints/RedisInstances.php
+++ b/src/Endpoints/RedisInstances.php
@@ -112,7 +112,6 @@ class RedisInstances extends Endpoint
             'cluster_id',
             'id',
             'port',
-            'unit_name',
         ]);
 
         $request = (new Request())
@@ -129,7 +128,6 @@ class RedisInstances extends Endpoint
                     'cluster_id',
                     'id',
                     'port',
-                    'unit_name',
                 ])
             );
 

--- a/src/Models/FpmPool.php
+++ b/src/Models/FpmPool.php
@@ -16,7 +16,6 @@ class FpmPool extends ClusterModel
     private ?int $cpuLimit = null;
     private ?int $logShowRequestsThreshold = null;
     private bool $isNamespaced = false;
-    private ?string $unitName = null;
     private ?int $id = null;
     private ?int $clusterId = null;
     private ?string $createdAt = null;
@@ -135,18 +134,6 @@ class FpmPool extends ClusterModel
         return $this;
     }
 
-    public function getUnitName(): ?string
-    {
-        return $this->unitName;
-    }
-
-    public function setUnitName(?string $unitName): self
-    {
-        $this->unitName = $unitName;
-
-        return $this;
-    }
-
     public function getId(): ?int
     {
         return $this->id;
@@ -207,7 +194,6 @@ class FpmPool extends ClusterModel
             ->setCpuLimit(Arr::get($data, 'cpu_limit'))
             ->setLogShowRequestsThreshold(Arr::get($data, 'log_slow_requests_threshold'))
             ->setIsNamespaced((bool)Arr::get($data, 'is_namespaced'))
-            ->setUnitName(Arr::get($data, 'unit_name'))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
@@ -226,7 +212,6 @@ class FpmPool extends ClusterModel
             'cpu_limit' => $this->getCpuLimit(),
             'log_slow_requests_threshold' => $this->getLogShowRequestsThreshold(),
             'is_namespaced' => $this->isNamespaced(),
-            'unit_name' => $this->getUnitName(),
             'id' => $this->getId(),
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),

--- a/src/Models/PassengerApp.php
+++ b/src/Models/PassengerApp.php
@@ -23,7 +23,6 @@ class PassengerApp extends ClusterModel
     private ?string $startupFile;
     private bool $isNamespaced = false;
     private ?int $cpuLimit = null;
-    private ?string $unitName;
     private ?int $id = null;
     private ?int $clusterId = null;
     private ?string $createdAt = null;
@@ -225,18 +224,6 @@ class PassengerApp extends ClusterModel
         return $this;
     }
 
-    public function getUnitName(): ?string
-    {
-        return $this->unitName;
-    }
-
-    public function setUnitName(?string $unitName): self
-    {
-        $this->unitName = $unitName;
-
-        return $this;
-    }
-
     public function getId(): ?int
     {
         return $this->id;
@@ -302,7 +289,6 @@ class PassengerApp extends ClusterModel
             ->setIsNamespaced((bool)Arr::get($data, 'is_namespaced'))
             ->setCpuLimit(Arr::get($data, 'cpu_limit'))
             ->setAppRoot(Arr::get($data, 'app_root'))
-            ->setUnitName(Arr::get($data, 'unit_name'))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
@@ -326,7 +312,6 @@ class PassengerApp extends ClusterModel
             'is_namespaced' => $this->isNamespaced(),
             'cpu_limit' => $this->getCpuLimit(),
             'app_root' => $this->getAppRoot(),
-            'unit_name' => $this->getUnitName(),
             'id' => $this->getId(),
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),

--- a/src/Models/RedisInstance.php
+++ b/src/Models/RedisInstance.php
@@ -15,7 +15,6 @@ class RedisInstance extends ClusterModel
     private int $memoryLimit = 100;
     private string $evictionPolicy;
     private int $primaryNodeId;
-    private ?string $unitName = null;
     private ?int $id = null;
     private ?int $clusterId = null;
     private ?string $createdAt = null;
@@ -120,18 +119,6 @@ class RedisInstance extends ClusterModel
         return $this;
     }
 
-    public function getUnitName(): ?string
-    {
-        return $this->unitName;
-    }
-
-    public function setUnitName(?string $unitName): self
-    {
-        $this->unitName = $unitName;
-
-        return $this;
-    }
-
     public function getId(): ?int
     {
         return $this->id;
@@ -190,7 +177,6 @@ class RedisInstance extends ClusterModel
             ->setMemoryLimit(Arr::get($data, 'memory_limit'))
             ->setEvictionPolicy(Arr::get($data, 'eviction_policy'))
             ->setPrimaryNodeId(Arr::get($data, 'primary_node_id'))
-            ->setUnitName(Arr::get($data, 'unit_name'))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
@@ -207,7 +193,6 @@ class RedisInstance extends ClusterModel
             'memory_limit' => $this->getMemoryLimit(),
             'eviction_policy' => $this->getEvictionPolicy(),
             'primary_node_id' => $this->getPrimaryNodeId(),
-            'unit_name' => $this->getUnitName(),
             'id' => $this->getId(),
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),


### PR DESCRIPTION
# Changes

Remove unit name from Redis instances, FPM pools, and Passenger apps.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
