### PR TITLE
Version 1.97.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 this package and not the cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) 
 for detailed information.
 
+## [1.97.1]
+
+### Added
+
+- `OPTIONS` to allowed log methods.
+
 ## [1.97.0]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Client for the [Cyberfusion Cluster API](https://cluster-api.cyberfusion.nl/).
 
-This client was built for and tested on the **1.179.7** version of the API.
+This client was built for and tested on the **1.179.8** version of the API.
 
 ## Support
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.97.0';
+    private const VERSION = '1.97.1';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
     private GuzzleClient $httpClient;
 

--- a/src/Enums/LogMethod.php
+++ b/src/Enums/LogMethod.php
@@ -8,6 +8,7 @@ class LogMethod
     public const POST = 'POST';
     public const PUT = 'PUT';
     public const PATCH = 'PATCH';
+    public const OPTIONS = 'OPTIONS';
     public const DELETE = 'DELETE';
     public const HEAD = 'HEAD';
 }


### PR DESCRIPTION
# Changes

Add `OPTIONS` to allowed log methods.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
